### PR TITLE
Add helper method for getting Mesh post-types

### DIFF
--- a/class.mesh-settings.php
+++ b/class.mesh-settings.php
@@ -32,6 +32,36 @@ class Mesh_Settings {
 	public static $plugin_name = LINCHPIN_MESH_PLUGIN_NAME;
 
 	/**
+	 * Store the Mesh post-types.
+	 *
+	 * @var array
+	 */
+	protected static $post_types;
+
+	/**
+	 * Store the default Mesh post-types for new installs.
+	 *
+	 * @var array
+	 */
+	protected static $default_post_types = array( 'page' => 1 );
+
+	/**
+	 * Gets the Mesh post-types.
+	 *
+	 * @return array An array of post-types.
+	 */
+	public static function get_post_types() {
+		if ( null === self::$post_types ) {
+			// Get the mesh post-types from the database. If nothing exists in the
+			// database, use the plugin's defaults.
+			self::$post_types = get_option( 'mesh_post_types', self::$default_post_types );
+			// Ensure the mesh_template post-type is always included.
+			self::$post_types += array( 'mesh_template' => 1 );
+		}
+		return self::$post_types;
+	}
+
+	/**
 	 * Initialize our plugin settings.
 	 *
 	 * @since 1.0.0
@@ -273,13 +303,9 @@ class Mesh_Settings {
 		// Parse incoming $args into an array and merge it with $defaults.
 		$args = wp_parse_args( $args, $defaults );
 
-		$options = get_option( 'mesh_post_types' );
+		$options = Mesh_Settings::get_post_types();
 
-		$checked = false;
-
-		if ( ! empty( $options[ $args['post_type'] ] ) ) {
-			$checked = true;
-		}
+		$checked = ! empty( $options[ $args['post_type'] ] );
 		?>
 
 		<?php if ( ! empty( $args['description'] ) ) : ?>

--- a/class.mesh-templates-ajax.php
+++ b/class.mesh-templates-ajax.php
@@ -52,7 +52,7 @@ class Mesh_Templates_AJAX {
 		    wp_die( -1 );
         }
 
-		$available_post_types = get_option( 'mesh_post_types', array() );
+		$available_post_types = Mesh_Settings::get_post_types();
 
 		$template_references = new WP_Query( array(
             'post_type' => $available_post_types,

--- a/class.mesh-templates.php
+++ b/class.mesh-templates.php
@@ -112,7 +112,8 @@ class Mesh_Templates {
 			'rewrite' => false,
 		) );
 
-		$available_post_types = Mesh_Settings::get_post_types();
+		$mesh_post_types_array = Mesh_Settings::get_post_types();
+		$available_post_types = array_keys( $mesh_post_types_array );
 
 		register_taxonomy( 'mesh_template_usage', $available_post_types, array(
 			'labels' => array(

--- a/class.mesh-templates.php
+++ b/class.mesh-templates.php
@@ -112,10 +112,7 @@ class Mesh_Templates {
 			'rewrite' => false,
 		) );
 
-		// Using an extra variable for the array to support PHP 5.4
-		$mesh_post_types_array = get_option( 'mesh_post_types' );
-		$mesh_post_types = array_keys( $mesh_post_types_array );
-		$available_post_types = array_merge( array( 'mesh_template' ), $mesh_post_types );
+		$available_post_types = Mesh_Settings::get_post_types();
 
 		register_taxonomy( 'mesh_template_usage', $available_post_types, array(
 			'labels' => array(

--- a/class.mesh.php
+++ b/class.mesh.php
@@ -299,7 +299,7 @@ class Mesh {
 	 */
 	function admin_init() {
 		if ( false === get_option( 'mesh_version' ) ) {
-			update_option( 'mesh_post_types', array( 'page' => 1, 'mesh_template' => 1 ) );
+			update_option( 'mesh_post_types', Mesh_Settings::get_post_types() );
 			update_option( 'mesh_version', LINCHPIN_MESH_VERSION );
 		}
 	}
@@ -316,9 +316,9 @@ class Mesh {
 	 * @return void
 	 */
 	public static function edit_page_form( $post ) {
-		$allowed_post_types = get_option( 'mesh_post_types' );
+		$allowed_post_types = Mesh_Settings::get_post_types();
 
-		if ( ! array_key_exists( $post->post_type, $allowed_post_types ) ) {
+		if ( empty( $allowed_post_types[ $post->post_type ] ) ) {
 			return;
 		}
 
@@ -646,7 +646,7 @@ class Mesh {
 	function wp_trash_post( $post_id ) {
 		$post_to_trash = get_post( $post_id );
 
-		$supported_post_types = get_option( 'mesh_post_types', array() );
+		$supported_post_types = Mesh_Settings::get_post_types();
 
 		if ( empty( $supported_post_types[ $post_to_trash->post_type ] ) ) {
 			return;
@@ -676,7 +676,7 @@ class Mesh {
 	function before_delete_post( $post_id ) {
 		$post_to_delete = get_post( $post_id );
 
-		$supported_post_types = get_option( 'mesh_post_types', array() );
+		$supported_post_types = Mesh_Settings::get_post_types();
 
 		if ( empty( $supported_post_types[ $post_to_delete->post_type ] ) ) {
 			return;
@@ -706,7 +706,7 @@ class Mesh {
 	function untrash_post( $post_id ) {
 		$trashed_post = get_post( $post_id );
 
-		$supported_post_types = get_option( 'mesh_post_types', array() );
+		$supported_post_types = Mesh_Settings::get_post_types();
 
 		if ( empty( $supported_post_types[ $trashed_post->post_type ] ) ) {
 			return;


### PR DESCRIPTION
Upon first time activation of the plugin, I received two PHP notices that stemmed from lines [116](https://github.com/linchpinagency/mesh/blob/master/class.mesh-templates.php#L116) and lines [118](https://github.com/linchpinagency/mesh/blob/master/class.mesh-templates.php#L118) of `class.mesh-templates.php`. This is due to the `mesh_post_types` option not existing at the time this bit of code is executed.

A bandaid fix would be to just cast the call to `get_option( 'mesh_post_types' )` on line 116 as an array, but that felt kinda dirty. A quick search in the codebase, revealed numerous calls to `get_option( 'mesh_post_types' )` so it felt like a helper method might be a better approach.

This commit fixes these PHP array notices that are triggered when activating the plugin for the first time due to the 'mesh_post_types' not existing. In addition, I added helper method for retrieving the mesh_post_types from the database instead of relying on `get_option()` exclusively.