### PR TITLE
Use 'current_time' instead of 'date' when setting

### DIFF
--- a/class.mesh-templates-duplicate.php
+++ b/class.mesh-templates-duplicate.php
@@ -146,7 +146,7 @@ class Mesh_Templates_Duplicate {
 			$status = 'publish';
 		}
 
-		$new_date = date( 'Y-m-d H:i:s' );
+		$new_date = current_time( 'Y-m-d H:i:s' );
 
 		$new_post = array(
 			'menu_order'     => $post->menu_order,


### PR DESCRIPTION
#117 

This fixes duplicate sections disappearing when published (because the post status is set to "future")