### PR TITLE
Fix PHP 5.3 Travis Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 sudo: false
+dist: trusty
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 sudo: false
-dist: trusty
+dist: precise
 
 notifications:
   email:


### PR DESCRIPTION
Travis is switching over to using `trusty` Ubuntu. This is causing the PHP `5.3` jobs to fail because `5.3` is deprecated on `trusty`. This pull instructs Travis to continue using the `precise` version of Ubuntu. We can remove this after `5.3` support is removed from the plugin in the future.