### PR TITLE
update: pass default parameter to duplicate_sections function

### DIFF
--- a/class.mesh-templates-ajax.php
+++ b/class.mesh-templates-ajax.php
@@ -217,7 +217,7 @@ class Mesh_Templates_AJAX {
 
 			$mesh_templates_duplicate = new Mesh_Templates_Duplicate();
 
-			$duplicate_sections = $mesh_templates_duplicate->duplicate_sections( $mesh_template_id, $post_id );
+			$duplicate_sections = $mesh_templates_duplicate->duplicate_sections( $mesh_template_id, $post_id, false );
 
 			if ( ! empty( $duplicate_sections ) ) {
 				echo wp_kses( $duplicate_sections, Mesh::get_admin_template_kses() );


### PR DESCRIPTION
update: Pass default value of **false** to duplicate_sections function

To test the update:

1. Be sure to have a Mesh Template available for selection
2. In a new page, pick a Mesh template and click the "Select Template" button.

If on the master branch (before merge), adding the Mesh Template will fail and the Network tab of Chrome's web inspector will show a 500 error on admin-ajax.php

After switching branches or merging the this fix into master, this error subsides and the selection of a Mesh Template works as expected.